### PR TITLE
Fix (or rather add) the username property

### DIFF
--- a/src/watchList.js
+++ b/src/watchList.js
@@ -25,6 +25,7 @@ const malToNormal = {
   my_tags: 'tags',
   // MyAnimeList values
   user_id: 'userID',
+  user_name: 'username',
   user_watching: 'nbWatching',
   user_completed: 'nbCompleted',
   user_onhold: 'nbOnHold',


### PR DESCRIPTION
This PR fix this bug: 
![](https://cdn.discordapp.com/attachments/356224772184735756/413708477861462017/unknown.png)
With this: 
![](https://cdn.discordapp.com/attachments/356224772184735756/413708623378776064/unknown.png)

As username is implemented in MAL's API: 
![](https://cdn.discordapp.com/attachments/356224772184735756/413709014002827265/unknown.png)