### PR TITLE
Allow various url configurations

### DIFF
--- a/src/info.js
+++ b/src/info.js
@@ -134,7 +134,7 @@ const getInfoFromURL = (url) => {
     axios.get(url)
       .then(({ data }) => {
         const res = parsePage(data)
-        res.id = +url.split('/').splice(-2, 1)[0]
+        res.id = +url.split(/\/+/)[3]
         resolve(res)
       })
       .catch(/* istanbul ignore next */(err) => reject(err))


### PR DESCRIPTION
Allows multiple url versions when using 'getInfoFromURL'.

When searching without a blob/query at the end of the url, the id will return as `NaN`.

This change will still accept the blob/query at the end of a url, but it will no longer be required to successfully retrieve the id of the media. 

Accepts:
- https://myanimelist.net/anime/20047/Sakura_Trick
- https://myanimelist.net/anime/20047
- https://myanimelist.net/anime/20047/
- https://myanimelist.net/anime/20047/Sakura_Trick?q=sakura