### PR TITLE
Add "members" to Seasonal release data model

### DIFF
--- a/src/seasons.js
+++ b/src/seasons.js
@@ -40,7 +40,8 @@ const getType = (type, $) => {
         fromType: prod.find('.source').text().trim(),
         nbEp: prod.find('.eps').find('a').text().trim().replace(' eps', ''),
         releaseDate: info.find('.info').find('span').text().trim(),
-        score: info.find('.scormem').find('.score').text().trim()
+        score: info.find('.scormem').find('.score').text().trim(),
+        members: info.find('.scormem').find('.member.fl-r').text().trim().replace(',', '')
       })
     }
   })

--- a/src/seasons.js
+++ b/src/seasons.js
@@ -41,7 +41,7 @@ const getType = (type, $) => {
         nbEp: prod.find('.eps').find('a').text().trim().replace(' eps', ''),
         releaseDate: info.find('.info').find('span').text().trim(),
         score: info.find('.scormem').find('.score').text().trim(),
-        members: info.find('.scormem').find('.member.fl-r').text().trim().replace(',', '')
+        members: info.find('.scormem').find('.member.fl-r').text().trim().replace(/,/g, '')
       })
     }
   })


### PR DESCRIPTION
I am only using this seasonal script for my project and the way I want to sort my data is by members to get an accurate representation of popularity. Also removed the "," since when I tried comparing the member numbers it led misleading orders.