### PR TITLE
Support for filtering seasons by specific type (TV New & TV Continuti…

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,10 +187,11 @@ Returns: An array of a maximum length of 10 containing [Search result data model
 
 This method get the list of anime, OVAs, movies and ONAs released (or planned to be released) during the season of the specified year
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-| year | number | The year |
-| season | string | The season, must be either `spring`, `summer`, `fall` or `winter` |
+| Parameter | Optional | Type | Description |
+| --- | --- |--- | --- |
+| year | No | number | The year |
+| season | No | string | The season, must be either `spring`, `summer`, `fall` or `winter` |
+| type | Yes | string | The type, must be either `TV`, `TVNew`, `TVCon`, `ONAs`, `OVAs`, `Specials` or `Movies` |
 
 Usage example: 
 
@@ -201,12 +202,28 @@ const year = 2017
 const season = 'fall'
 
 malScraper.getSeason(year, season)
-  // `data` is an object containing the following keys: 'TV', 'OVAs', 'ONAs', 'Movies' and 'Specials'
+  // `data` is an object containing the following keys: 'TV', 'TVNew', 'TVCon', 'OVAs', 'ONAs', 'Movies' and 'Specials'
   .then((data) => console.log(data))
   .catch((err) => console.log(err))
 ```
 
 Returns: A [Seasonal release data model](https://github.com/Kylart/MalScraper/blob/master/README.md#seasonal-release-data-model) object
+
+With type parameter:
+```javascript
+const malScraper = require('mal-scraper')
+
+const year = 2017
+const season = 'fall'
+const type = 'TV' // Optional type parameter, if not specificed will default to returning an object with all of possible type keys
+
+malScraper.getSeason(year, season, type)
+  // `data` is an array containing all the 'Seasonal anime release data objects' for the given type
+  .then((data) => console.log(data))
+  .catch((err) => console.log(err))
+```
+
+Returns: A [Seasonal anime release data model](https://github.com/Kylart/MalScraper/blob/master/README.md#seasonal-anime-release-data-model) object
 
 ### getWatchListFromUser()
 
@@ -529,6 +546,8 @@ Anime ratings can be either:
 | Property | Type | Description |
 | --- | --- | --- |
 | TV | array | An array of [Seasonal anime release data model](https://github.com/Kylart/MalScraper/blob/master/README.md#seasonal-anime-release-data-model) objects |
+| TVNew | array | An array of [Seasonal anime release data model](https://github.com/Kylart/MalScraper/blob/master/README.md#seasonal-anime-release-data-model) objects |
+| TVCon | array | An array of [Seasonal anime release data model](https://github.com/Kylart/MalScraper/blob/master/README.md#seasonal-anime-release-data-model) objects |
 | OVAs | array | An array of [Seasonal anime release data model](https://github.com/Kylart/MalScraper/blob/master/README.md#seasonal-anime-release-data-model) objects |
 | ONAs | array | An array of [Seasonal anime release data model](https://github.com/Kylart/MalScraper/blob/master/README.md#seasonal-anime-release-data-model) objects |
 | Movies | array | An array of [Seasonal anime release data model](https://github.com/Kylart/MalScraper/blob/master/README.md#seasonal-anime-release-data-model) objects |

--- a/src/seasons.js
+++ b/src/seasons.js
@@ -44,7 +44,7 @@ const getType = (type, $) => {
   }
 
   $(classToSearch).each(function () {
-    if (!$(this).hasClass('kids') && !$(this).hasClass('r18') && $(this)) {
+    if (!$(this).hasClass('kids') && !$(this).hasClass('r18')) {
       const general = $(this).find('div:nth-child(1)')
       const picture = $(this).find('.image').find('img')
       const prod = $(this).find('.prodsrc')

--- a/src/seasons.js
+++ b/src/seasons.js
@@ -100,6 +100,8 @@ const getSeasons = (year, season, type) => {
         if (typeof type === 'undefined') {
           resolve({
             TV: getType('TV', $),
+            TVNew: getType('TVNew', $),
+            TVCon: getType('TVCon', $),
             OVAs: getType('OVAs', $),
             ONAs: getType('ONAs', $),
             Movies: getType('Movies', $),

--- a/test/seasons.test.js
+++ b/test/seasons.test.js
@@ -118,12 +118,18 @@ test('getSeasons returns the right season', async t => {
     const data = await getSeason(2017, 'fall')
 
     t.is(typeof data.TV, 'object')
+    t.is(typeof data.TVNew, 'object')
+    t.is(typeof data.TVCon, 'object')
     t.is(typeof data.OVAs, 'object')
     t.is(typeof data.Movies, 'object')
     t.is(data.TV.length, 97)
+    t.is(data.TVNew.length, 58)
+    t.is(data.TVCon.length, 41)
     t.is(data.OVAs.length, 11)
     t.is(data.Movies.length, 20)
     t.is(data.TV[0].title, 'Mahoutsukai no Yome')
+    t.is(data.TVNew[0].title, 'Mahoutsukai no Yome')
+    t.is(data.TVCon[0].title, 'One Piece')
   } catch (e) {
     console.log(e.message)
     t.fail()

--- a/test/seasons.test.js
+++ b/test/seasons.test.js
@@ -29,7 +29,91 @@ test('getSeasons returns an error if not valid year', async t => {
   }
 })
 
-test.only('getSeasons returns the right season', async t => {
+test('getSeasons with type TV returns the correct season', async t => {
+  try {
+    const data = await getSeason(2017, 'fall', 'TV')
+
+    t.is(data.length, 97)
+    t.is(data[0].title, 'Mahoutsukai no Yome')
+  } catch (e) {
+    console.log(e.message)
+    t.fail()
+  }
+})
+
+test('getSeasons with type TVNew returns the correct season', async t => {
+  try {
+    const data = await getSeason(2017, 'fall', 'TVNew')
+
+    t.is(data.length, 58)
+    t.is(data[0].title, 'Mahoutsukai no Yome')
+  } catch (e) {
+    console.log(e.message)
+    t.fail()
+  }
+})
+
+test('getSeasons with type TVCon returns the correct season', async t => {
+  try {
+    const data = await getSeason(2017, 'fall', 'TVCon')
+
+    t.is(data.length, 41)
+    t.is(data[0].title, 'One Piece')
+  } catch (e) {
+    console.log(e.message)
+    t.fail()
+  }
+})
+
+test('getSeasons with type ONAs returns the correct season', async t => {
+  try {
+    const data = await getSeason(2017, 'fall', 'ONAs')
+
+    t.is(data.length, 56)
+    t.is(data[0].title, 'Hitori no Shita: The Outcast 2nd Season')
+  } catch (e) {
+    console.log(e.message)
+    t.fail()
+  }
+})
+
+test('getSeasons with type OVAs returns the correct season', async t => {
+  try {
+    const data = await getSeason(2017, 'fall', 'OVAs')
+
+    t.is(data.length, 11)
+    t.is(data[0].title, 'Shingeki no Kyojin: Lost Girls')
+  } catch (e) {
+    console.log(e.message)
+    t.fail()
+  }
+})
+
+test('getSeasons with type returns the correct season', async t => {
+  try {
+    const data = await getSeason(2017, 'fall', 'Specials')
+
+    t.is(data.length, 25)
+    t.is(data[0].title, 'Net-juu no Susume Special')
+  } catch (e) {
+    console.log(e.message)
+    t.fail()
+  }
+})
+
+test('getSeasons with type Movies returns the correct season', async t => {
+  try {
+    const data = await getSeason(2017, 'fall', 'Movies')
+
+    t.is(data.length, 20)
+    t.is(data[0].title, 'Fate/stay night Movie: Heaven\'s Feel - I. Presage Flower')
+  } catch (e) {
+    console.log(e.message)
+    t.fail()
+  }
+})
+
+test('getSeasons returns the right season', async t => {
   try {
     const data = await getSeason(2017, 'fall')
 


### PR DESCRIPTION
Allow for filtering seasonal data via different types including TV New & TV Continuing. Previously they were merged as one and this can be confusing when gathering data and maintaining specific anime's from each season (Without previous continuing anime's being bundled together)

Also added a full suite of test cases for the new type feature & fixed a couple bugs involving your synopsis & title gathering which can sometimes be undefined. :/

Example:
```js
const data = await malScraper.getSeason('2017', 'fall', 'TVNew')
const data = await malScraper.getSeason('2017', 'fall', 'TVCon')
const data = await malScraper.getSeason('2017', 'fall', 'OVAs') 
// The final parameter can be either 'TV', 'TVNew', 'TVCon', 'OVAs', 'ONAs', 'Movies' or 'Specials'
// Return value is accessible without a property type
// because there is only 1 property type for each request, Do not need to specify e.g.
let first  = data[0] // will access the contents of the first value
// NOT
let first = data.TVNew[0] 
```

If no type is provided it will default to the default method of gathering by all types e.g.
```js
const data = await malScraper.getSeason(year, season)
```