### PR TITLE
Set limit length to the keyword

### DIFF
--- a/src/info.js
+++ b/src/info.js
@@ -185,7 +185,7 @@ const getResultsFromSearch = (keyword) => {
     axios.get(SEARCH_URI, {
       params: {
         type: 'anime',
-        keyword
+        keyword: keyword.slice(0, 100)
       }
     }).then(({ data }) => {
       const items = []


### PR DESCRIPTION
I got this error while searching with more than 100 character

```json
{"errors":[{"message":"Your keyword length must save less than or equal to 100."}]}
```