### PR TITLE
Add status parameter for getWatchListFromUser

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,31 @@ Returns: A [Seasonal anime release data model](https://github.com/Kylart/MalScra
 
 ### getWatchListFromUser()
 
+#### From v2.11.6
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| username | string | The name of the user |
+| after | number | Useful to paginate. Is the number of results you want to start from. By default, MAL returns 300 entries only. |
+| type | string | Optional, can be either `anime` or `manga` |
+| status | number | Optional, Status in the user's watch list (completed, on-hold...) |
+
+Usage example:
+
+```javascript
+const malScraper = require('mal-scraper')
+
+const username = 'Kylart'
+const after = 25
+const type = 'anime' // can be either `anime` or `manga`
+const status = 7 // All anime
+
+// Get you an object containing all the entries with status, score... from this user's watch list
+malScraper.getWatchListFromUser(username, after, type, status)
+  .then((data) => console.log(data))
+  .catch((err) => console.log(err))
+```
+
 #### From v2.6.0
 
 | Parameter | Type | Description |

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -43,6 +43,28 @@ declare module 'mal-scraper' {
     type?: Types
   ): Promise<SeasonDataModel>;
 
+
+  /**
+   * Get the watchlist of the given user.
+   * @param username The username of the user to search.
+   * @param after Useful to paginate. Is the number of results you want to start from. By default, MAL returns 300 entries only.
+   * @param type Optional, can be either `anime` or `manga`.
+   * @param status Optional, Status in the user's watch list (completed, on-hold...)
+   * @note From v2.11.6.
+   */
+  export function getWatchListFromUser<T extends AllowedTypes = 'anime'>(
+    username: string,
+    after?: number,
+    type?: T,
+    status?: number
+  ): Promise<
+    T extends 'anime'
+      ? UserAnimeEntryDataModel[]
+      : T extends 'manga'
+      ? UserMangaEntryDataModel[]
+      : never
+  >;
+
   /**
    * Get the watchlist of the given user.
    * @param username The username of the user to search.
@@ -353,6 +375,16 @@ declare module 'mal-scraper' {
    * `6` - Plan-to-Watch | Plan-to-Read
    */
   type StatusReference = 1 | 2 | 3 | 4 | 6;
+
+  /**
+   * `1` - Watching | Reading\
+   * `2` - Completed\
+   * `3` - On-Hold\
+   * `4` - Dropped\
+   * `6` - Plan-to-Watch | Plan-to-Read\
+   * `7` - All status above
+   */
+    type SearchStatusReference = StatusReference | 7
 
   /**
    * `1` - Currently airing | Publishing\

--- a/src/watchList.js
+++ b/src/watchList.js
@@ -21,11 +21,12 @@ const format = (obj) => {
  * @param {string} user The name of the user.
  * @param {number} after How many results you already have.
  * @param {string} type Can be either 'anime' or 'manga'
+ * @param {number} status Status in the user's watch list (completed, on-hold...)
  *
  * @returns {promise}
  */
 
-const getWatchListFromUser = (user, after = 0, type = 'anime') => {
+const getWatchListFromUser = (user, after = 0, type = 'anime', status = 7) => {
   return new Promise((resolve, reject) => {
     if (!user) {
       reject(new Error('[Mal-Scraper]: No user received.'))
@@ -34,7 +35,8 @@ const getWatchListFromUser = (user, after = 0, type = 'anime') => {
 
     axios.get(`https://myanimelist.net/${type}list/${user}/load.json`, {
       params: {
-        offset: after
+        offset: after,
+        status
       }
     })
       .then(({ data }) => {


### PR DESCRIPTION
By default, when searching a user's watchlist, MAL returns only the anime currently being watched.

So I added the status parameter which I set to 7 by default (all status are returned)

So we should go from https://myanimelist.net/animelist/aeden/load.json to https://myanimelist.net/animelist/aeden/load.json?offset=0 to https://myanimelist.net/animelist/aeden/load.json?offset=0&status=7 by default.