### PR TITLE
Added Support for Manga to getInfoFromName() and getResultsFromSearch()

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ or [Manga search model](https://github.com/Kylart/MalScraper/blob/master/README.
 | --- | --- | --- |
 | Name | string | The name of the anime to search, the best match corresponding to that name will be returned |
 | getBestMatch | Boolean | Whether you want to use [`match-sorter`](https://github.com/kentcdodds/match-sorter) to find the best result or not (defaults to true) |
+| type | string | The type, can be either `manga` or `anime`. Default is `anime` |
 
 Usage example:
 
@@ -151,6 +152,15 @@ malScraper.getInfoFromName(name, true)
   .catch((err) => console.log(err))
 
 malScraper.getInfoFromName(name, false)
+  .then((data) => console.log(data))
+  .catch((err) => console.log(err))
+
+// same as
+malScraper.getInfoFromName(name, true, 'anime')
+  .then((data) => console.log(data))
+  .catch((err) => console.log(err))
+
+malScraper.getInfoFromName(name, false, 'anime')
   .then((data) => console.log(data))
   .catch((err) => console.log(err))
 ```
@@ -184,6 +194,7 @@ Returns: A [Anime data model](https://github.com/Kylart/MalScraper/blob/master/R
 | Parameter | Type | Description |
 | --- | --- | --- |
 | query | string | The search query |
+| type | string | The type, can be either `manga` or `anime`. Default is `anime` |
 
 Usage example:
 
@@ -192,7 +203,7 @@ const malScraper = require('mal-scraper')
 
 const query = 'sakura'
 
-malScraper.getResultsFromSearch(query)
+malScraper.getResultsFromSearch(query, 'anime')
   .then((data) => console.log(data))
   .catch((err) => console.log(err))
 ```

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,10 +11,17 @@ declare module 'mal-scraper' {
    * @param getBestMatch Whether you want to use [`match-sorter`](https://github.com/kentcdodds/match-sorter) to find the best result or not. (Default to `true`)
    * @returns A promise that resolves to an object containing the infos about the anime.
    */
-  export function getInfoFromName<B extends boolean = true>(
+  export function getInfoFromName<B extends boolean = true, T extends AllowedTypes = 'anime'>(
     name: string,
-    getBestMatch?: B
-  ): Promise<AnimeDataModel>;
+    getBestMatch?: B,
+    type?: T,
+  ): Promise<
+  T extends 'anime'
+    ? AnimeDataModel
+    : T extends 'manga'
+    ? MangaDataModel
+    : never
+  >;
 
   /**
    * Get infos about an anime from the given URL.
@@ -27,8 +34,9 @@ declare module 'mal-scraper' {
    * Return an array of a maximum length of 10 containing {@link SearchResultsDataModel Search result data model} objects.
    * @param query The query to search.
    */
-  export function getResultsFromSearch(
-    query: string
+  export function getResultsFromSearch<T extends AllowedTypes = 'anime'>(
+    query: string,
+    type?: T
   ): Promise<SearchResultsDataModel[]>;
 
   /**
@@ -858,39 +866,34 @@ declare module 'mal-scraper' {
 
   interface MangaDataModel {
     /**
-     * The unique identifier of this manga
-     */
-    id: string;
-
-    /**
      * The title of the manga
      */
     title: string;
 
     /**
+     * The synopsis of the manga
+     */
+    synopsis?: string;
+
+    /**
+     * An URL to the manga's cover image
+     */
+    picture?: string;
+
+    /**
+     * An array of {@link CharacterDataModel Character data model} objects.
+     */
+    characters?: CharacterDataModel[];
+
+    /**
      * The english title of the manga
      */
-    english?: string;
+    englishTitle?: string;
 
     /**
      * A set of synonyms for the manga
      */
     synonyms?: string[];
-
-    /**
-     * Total count of chapters this manga has
-     */
-    chapters?: string;
-
-    /**
-     * Total count of volumes this manga has
-     */
-    volumes?: string;
-
-    /**
-     * The average score given by users to this manga
-     */
-    score?: string;
 
     /**
      * The type of the manga (Manga, Doujinshi...)
@@ -913,14 +916,75 @@ declare module 'mal-scraper' {
     end_date?: string;
 
     /**
-     * The synopsis of the manga
+     * Total count of volumes this manga has
      */
-    synopsis?: string;
+    volumes?: string;
 
     /**
-     * An URL to the manga's cover image
+     * Total count of chapters this manga has
      */
-    image?: string;
+    chapters?: string;
+
+    /**
+     * The date from which the publishing started to the one from which it ended,
+     * this property will be empty if one of the two dates is unknown
+     */
+    published?: string;
+
+    /**
+     * The authors of the novel
+     */
+    authors?: string;
+
+    /**
+     * The serialization of the novel
+     */
+    serialization?: string;
+
+    /**
+     * An array of genres of the manga (Action, Slice of Life, Drama, etc.)
+     */
+    genres?: GenreName[];
+
+    /**
+     * The average score given by users to this manga
+     */
+    score?: string;
+
+    /**
+     * By how many users this manga has been rated, like `"scored by 255,693 users"`
+     */
+    scoreStats?: string;
+
+    /**
+     * The rank of the manga
+     */
+    ranked?: string;
+
+    /**
+     * The popularity of the manga
+     */
+    popularity?: string;
+
+    /**
+     * How many users are members of the manga (have it on their list)
+     */
+    members?: string;
+
+    /**
+     * The count of how many users marked this manga as favorite
+     */
+    favorites?: string;
+
+    /**
+     * The unique identifier of this manga
+     */
+    id: string;
+
+    /**
+     * The URL of the manga page
+     */
+    url: string;
   }
 
   interface CharacterDataModel {

--- a/src/info.js
+++ b/src/info.js
@@ -178,7 +178,7 @@ const getInfoFromURL = (url) => {
   })
 }
 
-const getResultsFromSearch = (keyword) => {
+const getResultsFromSearch = (keyword, type = 'anime') => {
   return new Promise((resolve, reject) => {
     if (!keyword) {
       reject(new Error('[Mal-Scraper]: Received no keyword to search.'))
@@ -187,7 +187,7 @@ const getResultsFromSearch = (keyword) => {
 
     axios.get(SEARCH_URI, {
       params: {
-        type: 'anime',
+        type: type,
         keyword: keyword.slice(0, 100)
       }
     }).then(({ data }) => {
@@ -206,14 +206,14 @@ const getResultsFromSearch = (keyword) => {
   })
 }
 
-const getInfoFromName = (name, getBestMatch = true) => {
+const getInfoFromName = (name, getBestMatch = true, type = 'anime') => {
   return new Promise((resolve, reject) => {
     if (!name || typeof name !== 'string') {
       reject(new Error('[Mal-Scraper]: Invalid name.'))
       return
     }
 
-    getResultsFromSearch(name)
+    getResultsFromSearch(name, type)
       .then(async (items) => {
         if (!items.length) {
           resolve(null)


### PR DESCRIPTION
Tested both & working. Also went through and edited MangaDataModel's typings to contain the information actually given & keep it up to date with AnimeDataModel.

I did notice theres some overlap between AnimeDataModel & MangaDataModel, is there a desire to keep manga information in the AnimeDataModel? If not I can remove the overlap, if so I can merge MangaDataModel into AnimeDataModel.

I'm assuming this won't mess with anything else as it will still default to anime searching.

I only needed these two so I haven't added support to anything else but if a change like this is wanted I can work on adding manga support to everything else that needs it.