### PR TITLE
Fix match-sorter import

### DIFF
--- a/src/info.js
+++ b/src/info.js
@@ -1,6 +1,6 @@
 const axios = require('axios')
 const cheerio = require('cheerio')
-const match = require('match-sorter').default
+const { matchSorter } = require('match-sorter')
 
 const SEARCH_URI = 'https://myanimelist.net/search/prefix.json'
 
@@ -226,7 +226,7 @@ const getInfoFromName = (name, getBestMatch = true, type = 'anime') => {
           return
         }
         try {
-          const bestMatch = match(items, name, { keys: ['name'] })
+          const bestMatch = matchSorter(items, name, { keys: ['name'] })
           const itemMatch = getBestMatch && bestMatch && bestMatch.length ? bestMatch[0] : items[0]
           const url = itemMatch.url
           const data = await getInfoFromURL(url)


### PR DESCRIPTION
hello, maintainers!

in version 2.13.0, match-sorter bumped from 4.0.2 to 6.3.1. seems like the match-sorter@6.3.1 doesn't work as it should.
```
mal-scraper\src\info.js:229
          const bestMatch = match(items, name, { keys: ['name'] })
                            ^

TypeError: match is not a function
    at D:\File\Visual Studio Code\react-pages\node_modules\mal-scraper\src\info.js:229:29
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```
this pull request fixes the import statements, it ensures that the module are imported according to the documentation stated in the [match-sorter](https://github.com/kentcdodds/match-sorter#usage).

[[GitHub] Default export no longer supported](https://github.com/kentcdodds/match-sorter/releases/tag/v5.0.0)
[[Imgur] Fix Result](https://imgur.com/a/E9kr1ct)