### PR TITLE
fix: episode names over 12 missing

### DIFF
--- a/src/episodes.js
+++ b/src/episodes.js
@@ -8,10 +8,7 @@ const parsePage = ($) => {
   const allItems = $('tr.episode-list-data')
   const result = []
 
-  // Because MAL shows twice the number of elements for the order
-  const items = allItems.slice(0, allItems.length / 2)
-
-  items.each(function (elem) {
+  allItems.each(function (elem) {
     result.push({
       epNumber: +$(this).find('td.episode-number').text().trim(),
       aired: $(this).find('td.episode-aired').text().trim(),


### PR DESCRIPTION
Half of the episodes were missing when doing some queries. I found this section was the issue. I wonder if the information in the comment is old.