### PR TITLE
fix ts declaration for producersList

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -420,7 +420,7 @@ declare module 'mal-scraper' {
 
     orderTypes: OrderTypes;
 
-    producerList: {
+    producersList: {
       anime: {
         name: string;
         value: string;


### PR DESCRIPTION
actual helper property name is `producersList` but is declared as `producerList`

[src/search/index.js#L218](https://github.com/Kylart/MalScraper/blob/dev/src/search/index.js#L218)
```js
  helpers: {
    availableValues,
    producersList: lists.producers,
    genresList: lists.genres,
    orderTypes: Object.keys(orderMap.keys)
  }
  ```
[src/index.d.ts#L423C5-L423C18](https://github.com/Kylart/MalScraper/blob/dev/src/index.d.ts#L423C5-L423C18)
```ts
    producerList: {
      anime: {
        name: string;
        value: string;
      }[];
      manga: {
        name: string;
        value: string;
      }[];
    };
```